### PR TITLE
feat: Implement archive script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 By participating in this project you agree to abide by its terms.
 
-We appreciate you taking the time to contribute to `@octoherd/script-delete-repository`. Especially as a new contributor, you have a valuable perspective that we lost a long time ago: you will find things confusing and run into problems that no longer occur to us. Please share them with us, so we can make the experience for future contributors the best it could be.
+We appreciate you taking the time to contribute to `@octoherd/script-archive-repository`. Especially as a new contributor, you have a valuable perspective that we lost a long time ago: you will find things confusing and run into problems that no longer occur to us. Please share them with us, so we can make the experience for future contributors the best it could be.
 
 Thank you 💖
 
@@ -11,7 +11,7 @@ Thank you 💖
 
 Before you create a new Issue:
 
-1. Please make sure there is no [open issue](https://github.com/octoherd/script-delete-repository/issues?utf8=%E2%9C%93&q=is%3Aissue) yet.
+1. Please make sure there is no [open issue](https://github.com/octoherd/script-archive-repository/issues?utf8=%E2%9C%93&q=is%3Aissue) yet.
 2. If it is a bug report, include the steps to reproduce the issue
 3. If it is a feature request, please share the motivation for the new feature, what alternatives you tried, and how you would implement it.
 
@@ -22,8 +22,8 @@ First, fork the repository.
 Setup the repository locally. Replace `<your account name>` with the name of the account you forked to.
 
 ```shell
-git clone https://github.com/<your account name>/script-delete-repository.git
-cd script-delete-repository
+git clone https://github.com/<your account name>/script-archive-repository.git
+cd script-archive-repository
 npm install
 ```
 
@@ -37,7 +37,7 @@ npm test
 
 - Create a new branch locally.
 - Make your changes in that branch and push them to your fork
-- Submit a pull request from your topic branch to the main branch on the `octoherd/script-delete-repository` repository.
+- Submit a pull request from your topic branch to the main branch on the `octoherd/script-archive-repository` repository.
 - Be sure to tag any issues your pull request is taking care of / contributing to. Adding "Closes #123" to a pull request description will automatically close the issue once the pull request is merged in.
 
 ## Maintainers only

--- a/README.md
+++ b/README.md
@@ -1,25 +1,24 @@
-# script-delete-repository
+# script-archive-repository
 
-> An Octoherd script to delete repositories
+> An Octoherd script to archive repositories
 
-[![@latest](https://img.shields.io/npm/v/@octoherd/script-delete-repository.svg)](https://www.npmjs.com/package/@octoherd/script-delete-repository)
-[![Build Status](https://github.com/octoherd/script-delete-repository/workflows/Test/badge.svg)](https://github.com/octoherd/script-delete-repository/actions?query=workflow%3ATest+branch%3Amain)
+[![@latest](https://img.shields.io/npm/v/@octoherd/script-archive-repository.svg)](https://www.npmjs.com/package/@octoherd/script-archive-repository)
+[![Build Status](https://github.com/octoherd/script-archive-repository/workflows/Test/badge.svg)](https://github.com/octoherd/script-archive-repository/actions?query=workflow%3ATest+branch%3Amain)
 
 ## Usage
 
-Minimal usage (You have to set a token because the built-in OAuth flow creates a token with the `repo` scope, but this script requires the `delete_repo` scope. You can create such a token at https://github.com/settings/tokens/new?scopes=delete_repo)
-
 ```js
-npx @octoherd/script-delete-repository \
+npx @octoherd/script-archive-repository \
   -T ghp_0123456789abcdefghjklmnopqrstuvwxyzA \
 ```
 
 Pass all options as CLI flags to avoid user prompts
 
 ```js
-npx @octoherd/script-delete-repository \
+npx @octoherd/script-archive-repository \
   -T ghp_0123456789abcdefghjklmnopqrstuvwxyzA \
-  -R "octoherd/*"
+  -R "octoherd/Hello-World" \
+  --octoherd-bypass-confirms
 ```
 
 ## Options

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@octoherd/script-delete-repository",
+  "name": "@octoherd/script-archive-repository",
   "version": "0.0.0-development",
   "type": "module",
   "exports": "./script.js",
   "bin": {
-    "octoherd-script-delete-repository": "./cli.js"
+    "octoherd-script-archive-repository": "./cli.js"
   },
-  "description": "An Octoherd script to delete repositories",
+  "description": "An Octoherd script to archive repositories",
   "scripts": {
     "start": "node cli.js",
     "test": "node script.js"
   },
-  "repository": "https://github.com/octoherd/script-delete-repository",
+  "repository": "https://github.com/octoherd/script-archive-repository",
   "keywords": [
     "octoherd-script"
   ],

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /** @type boolean */
-let hasDeleteRepoScope;
+let hasRepoScope;
 
 /**
  * An Octoherd script to delete repositories
@@ -10,21 +10,37 @@ let hasDeleteRepoScope;
  * @param {import('@octoherd/cli').Repository} repository
  */
 export async function script(octokit, repository) {
-  if (!hasDeleteRepoScope) {
+  if (!hasRepoScope) {
     const { headers } = await octokit.request("HEAD /");
     const scopes = new Set(headers["x-oauth-scopes"].split(", "));
 
-    if (!scopes.has("delete_repo")) {
+    if (!scopes.has("repo")) {
       throw new Error(
-        `The "delete_repo" scope is required for this script. Create a token at https://github.com/settings/tokens/new?scopes=delete_repo then run the script with "-T <paste token here>"`
+        `The "repo" scope is required for this script. Create a token at https://github.com/settings/tokens/new?scopes=repo then run the script with "-T <paste token here>"`
       );
     }
-    hasDeleteRepoScope = true;
+    hasRepoScope = true;
   }
 
-  await octokit.request("DELETE /repos/{owner}/{repo}", {
+  const archived = await octokit.request("PATCH /repos/{owner}/{repo}", {
     owner: repository.owner.login,
     repo: repository.name,
-  });
-  octokit.log.info("Repository deleted");
+    data: {
+      archived: true,
+    }
+  })
+    .then(() => true)
+    .catch(error => {
+      // error.message: Repository was archived so is read-only
+      if (error.status === 403 && error.message.includes("archived")) {
+        octokit.log.warn(`Repository is already archived`);
+        return false;
+      }
+
+      throw error;
+    })
+
+  if (archived) {
+    octokit.log.info("Repository archived");
+  }
 }


### PR DESCRIPTION
The current base is an exact copy of [octoherd/script-delete-repository](https://github.com/octoherd/script-delete-repository). This pull request implements the option to `archive` repositories using [PATCH /repos/{owner}/{repo}](https://docs.github.com/en/rest/reference/repos#update-a-repository). If a repository is already archived, the script logs a warning. 